### PR TITLE
Fix Twitter share text to point to @cloudnativeams

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,0 +1,2 @@
+[twitter_share_text]
+other = "Come join us at the Kubernetes Community Days @cloudnativeams #Kubernetes #Amsterdam"


### PR DESCRIPTION
Hey I noticed the Twitter share link in the footer of the website was pointing at the wrong conference 😉

You might want to look into the copy, this is just a suggestion feel free to edit 🙂