### PR TITLE
Fixed FB sharer link and FB page

### DIFF
--- a/data/footer.yml
+++ b/data/footer.yml
@@ -1,15 +1,17 @@
 share:
   - name: facebook
-    url: https://www.facebook.com/sharer.php?u=
+    url: https://www.facebook.com/sharer.php?u=https://cloudnative.amsterdam/
   - name: twitter
-    url: https://twitter.com/intent/tweet?text=
+    url: https://twitter.com/intent/tweet?text=https://cloudnative.amsterdam/
 
 follow:
   - name: twitter
     url: https://twitter.com/cloudnativeams
   - name: instagram
     url: https://www.instagram.com/cloudnativeams
-
+  - name: Facebook
+    url: https://www.facebook.com/cloudnativeams
+    
 content:
   - title: footer_about
     links:


### PR DESCRIPTION
Created an FB page at https://www.facebook.com/cloudnativeams and fixed the sharer link